### PR TITLE
Change commmit subject warning to 72 characters

### DIFF
--- a/src/validate-commit-msg.hs
+++ b/src/validate-commit-msg.hs
@@ -93,7 +93,7 @@ lintMsg msg0 = execWriter $ do
 
            if | slen > 80 -> errSubj  ("subject line longer than 80 characters (was " <> tshow slen <> " characters)"
                                        <> " -- , ideally subject line is at most 50 characters long")
-              | slen > 50 -> warnSubj ("subject line longer than 50 characters (was " <> tshow slen <> " characters)")
+              | slen > 72 -> warnSubj ("subject line longer than 72 characters (was " <> tshow slen <> " characters)")
               | slen < 8  -> errSubj  ("subject line shorter than 8 characters (was " <> tshow slen <> " characters)")
               | otherwise -> return ()
 


### PR DESCRIPTION
- A warning suggests something is wrong. Commit authors might now leave
  out the Trac ticket number or other useful information from the
  subject line, just to try to keep within 50 characters. I think this
  is a mistake, and the 50 character limit warning should be lifted.
- I cannot find any good rational for the 50 character limit. It's seems
  to be just a suggestion by tpope ("you should shoot for about 50
  characters (though this isn’t a hard maximum)"). So for the moment, I
  left it a suggestion in the 80 character hard limit message. But this
  is what the Linux kernel documentation has to say for example (and i
  agree wholeheartedly):
  
    Bear in mind that the "summary phrase" of your email becomes a
    globally-unique identifier for that patch.  It propagates all the
    way into the git changelog.  The "summary phrase" may later be used
    in developer discussions which refer to the patch.  People will want
    to google for the "summary phrase" to read discussion regarding that
    patch.  It will also be the only thing that people may quickly see
    when, two or three months later, they are going through perhaps
    thousands of patches using tools such as "gitk" or "git log
    --oneline".
  
    For these reasons, the "summary" must be no more than 70-75
    characters, and it must describe both what the patch changes, as
    well as why the patch might be necessary.  It is challenging to be
    both succinct and descriptive, but that is what a well-written
    summary should do.
- With 'git log --oneline', a 72 character subject line just fits in a
  80 character window.
